### PR TITLE
Consistently parse Cli flags for traitlets 5.0.

### DIFF
--- a/traitlets/config/application.py
+++ b/traitlets/config/application.py
@@ -661,6 +661,7 @@ class Application(SingletonConfigurable):
     @catch_config_error
     def parse_command_line(self, argv=None):
         """Parse the command line arguments."""
+        assert not isinstance(argv, str)
         argv = sys.argv[1:] if argv is None else argv
         self.argv = [cast_unicode(arg) for arg in argv ]
 

--- a/traitlets/config/loader.py
+++ b/traitlets/config/loader.py
@@ -49,6 +49,18 @@ class ArgumentError(ConfigLoaderError):
 # to do.  So we override the print_help method with one that defaults to
 # stdout and use our class instead.
 
+
+class _Sentinel:
+    def __repr__(self):
+        return "<Sentinel deprecated>"
+
+    def __str__(self):
+        return "<deprecated>"
+
+
+_deprecated = _Sentinel()
+
+
 class ArgumentParser(argparse.ArgumentParser):
     """Simple argparse subclass that prints help to stdout by default."""
 
@@ -690,6 +702,7 @@ flag_pattern = re.compile(r'\-\-?\w+[\-\w]*$')
 
 class _KVAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
+        values = ["-" if v is _DASH_REPLACEMENT else v for v in values]
         items = getattr(namespace, self.dest, None)
         if items is None:
             items = DeferredConfigList()
@@ -700,7 +713,7 @@ class _KVAction(argparse.Action):
 
 
 _DOT_REPLACEMENT = "__DOT__"
-
+_DASH_REPLACEMENT = "__DASH__"
 
 class _DefaultOptionDict(dict):
     """Like the default options dict
@@ -755,7 +768,7 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         ipython --InteractiveShell.autocall=False
     """
 
-    def __init__(self, argv=None, classes=None, **kw):
+    def __init__(self, argv=None, classes=None, aliases=None, **kw):
         """Create a key value pair config loader.
 
         Parameters
@@ -785,8 +798,11 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         super(KeyValueConfigLoader, self).__init__(**kw)
         if argv is None:
             argv = sys.argv[1:]
+        for a in argv:
+            assert isinstance(a, str)
         self.argv = argv
         self.classes = classes or ()
+        self.aliases = aliases
 
 
     def clear(self):
@@ -820,13 +836,12 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
                     return parent.class_traits().get(trait_name)
         return None
 
-    def load_config(self, argv=None, aliases=None, flags=None):
+    def load_config(self, argv=None, aliases=None, flags=_deprecated):
         """Parse the configuration and generate the Config object.
 
-        After loading, any arguments that are not key-value or
-        flags will be stored in self.extra_args - a list of
-        unparsed command-line arguments.  This is used for
-        arguments such as input files or subcommands.
+        After loading, any arguments that are not key-value will be stored in
+        self.extra_args - a list of unparsed command-line arguments. This is
+        used for arguments such as input files or subcommands.
 
         Parameters
         ----------
@@ -838,9 +853,10 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
         self.clear()
         if argv is None:
             argv = self.argv
+        assert isinstance(argv, list)
         if aliases:
             raise ValueError("%s does not support aliases" % self.__class__.__name__)
-        if flags:
+        if flags is not _deprecated:
             raise ValueError("%s does not support flags" % self.__class__.__name__)
 
         parser = _KVArgParser()
@@ -851,6 +867,8 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
             extra_args = []
         else:
             argv, extra_args = argv[:idx], argv[idx+1:]
+
+        argv = [_DASH_REPLACEMENT if a == "-" else a for a in argv]
 
         options = parser.parse_args(argv)
 
@@ -870,7 +888,6 @@ class KeyValueConfigLoader(CommandLineConfigLoader):
                 self._exec_config_str(lhs, rhs, trait)
             except Exception:
                 raise ArgumentError("Invalid argument: '%s=%s'" % (lhs, rhs))
-
         return self.config
 
 
@@ -920,7 +937,7 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
         kwargs.update(parser_kw)
         self.parser_kw = kwargs
 
-    def load_config(self, argv=None, aliases=None, flags=None, classes=None):
+    def load_config(self, argv=None, aliases=None, flags=_deprecated, classes=None):
         """Parse command line arguments and return as a Config object.
 
         Parameters
@@ -929,11 +946,24 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
         args : optional, list
           If given, a list with the structure of sys.argv[1:] to parse
           arguments from. If not given, the instance's self.argv attribute
-          (given at construction time) is used."""
+          (given at construction time) is used.
+        flags
+          Deprecated in traitlets 5.0, instanciate the config loader with the flags.
+
+        """
+
+        if flags is not _deprecated:
+            wanring.warn(
+                "The `flag` argument to load_config is deprecated since Traitlets "
+                "5.0 and will be ignored, pass flags the `{type(self)}` constructor.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         self.clear()
         if argv is None:
             argv = self.argv
-        self._create_parser(aliases, flags, classes)
+        self._create_parser(aliases, self.flags, classes)
         self._parse_args(argv)
         self._convert_to_config()
         return self.config
@@ -944,7 +974,7 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
         else:
             return []
 
-    def _create_parser(self, aliases=None, flags=None, classes=None):
+    def _create_parser(self, aliases, flags, classes):
         self.parser = ArgumentParser(*self.parser_args, **self.parser_kw)
         self._add_arguments(aliases, flags, classes)
 
@@ -956,6 +986,35 @@ class ArgParseConfigLoader(CommandLineConfigLoader):
         # decode sys.argv to support unicode command-line options
         enc = DEFAULT_ENCODING
         uargs = [cast_unicode(a, enc) for a in args]
+
+        unpacked_aliases = {}
+        if self.aliases:
+            unpacked_aliases = {}
+            for k, v in self.aliases.items():
+                if k in self.flags:
+                    continue
+                if not isinstance(k, tuple):
+                    k1, k2 = k, None
+                else:
+                    k1, k2 = k
+                for al in (k1, k2):
+                    if al is None:
+                        continue
+                    if len(al) == 1:
+                        unpacked_aliases["-" + al] = "--" + v
+                    else:
+                        unpacked_aliases["--" + al] = "--" + v
+
+        def _replace(arg):
+            for k, v in unpacked_aliases.items():
+                if arg == k:
+                    return v
+                if arg.startswith(k + "="):
+                    return v + "=" + arg[len(k) + 1 :]
+            return arg
+
+        uargs = [_replace(a) for a in uargs]
+
         self.parsed_data, self.extra_args = self.parser.parse_known_args(uargs)
 
     def _convert_to_config(self):
@@ -994,7 +1053,6 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
 
     def _add_arguments(self, aliases=None, flags=None, classes=None):
         alias_flags = {}
-        # print aliases, flags
         if aliases is None:
             aliases = self.aliases
         if flags is None:
@@ -1079,7 +1137,9 @@ class KVArgParseConfigLoader(ArgParseConfigLoader):
             self._load_flag(subc)
 
         if self.extra_args:
-            sub_parser = KeyValueConfigLoader(log=self.log, classes=self.classes)
+            sub_parser = KeyValueConfigLoader(
+                log=self.log, classes=self.classes, aliases=self.aliases
+            )
             sub_parser.load_config(self.extra_args)
             self.config.merge(sub_parser.config)
             self.extra_args = sub_parser.extra_args

--- a/traitlets/config/tests/test_application.py
+++ b/traitlets/config/tests/test_application.py
@@ -188,9 +188,9 @@ class TestApplication(TestCase):
         app.parse_command_line("--li 1 --li 3 --la 1 --tb AB 2 --Foo.la=ab --Bar.aset S1 S2 S1".split())
         config = app.config
         assert config.Foo.li == [1, 3]
-        assert config.Foo.la == ['1', 'ab']
-        assert config.Bar.tb == ['AB', '2']
-        self.assertEqual(config.Bar.aset, 'S1 S2 S1'.split())
+        assert config.Foo.la == ["1", "ab"]
+        assert config.Bar.tb == ("AB", "2")
+        self.assertEqual(config.Bar.aset, {"S1", "S2"})
         app.init_foo()
         assert app.foo.li == [1, 3]
         assert app.foo.la == ['1', 'ab']
@@ -420,8 +420,10 @@ class TestApplication(TestCase):
         self.assertEqual(app.extra_args, ['extra', '--disable', 'args'])
 
         app = MyApp()
-        app.parse_command_line(['-', '--disable', '--Bar.b=1', '-', 'extra'])
-        self.assertEqual(app.extra_args, ['-', '-', 'extra'])
+        app.parse_command_line(
+            ["--disable", "--la", "-", "-", "--Bar.b=1", "--", "-", "extra"]
+        )
+        self.assertEqual(app.extra_args, ["-", "extra"])
 
     def test_unicode_argv(self):
         app = MyApp()
@@ -580,7 +582,7 @@ class TestApplication(TestCase):
 
             app.load_config_file(name, path=[td1])
             self.assertEqual(len(app.loaded_config_files), 1)
-            self.assertEquals(app.loaded_config_files[0], config_file)
+            self.assertEqual(app.loaded_config_files[0], config_file)
 
             app.start()
             self.assertEqual(app.running, True)

--- a/traitlets/config/tests/test_loader.py
+++ b/traitlets/config/tests/test_loader.py
@@ -316,17 +316,6 @@ class TestKeyValueCL(TestCase):
         print(config)
         self.assertEqual(config.a, u'épsîlön')
 
-    def test_unicode_bytes_args(self):
-        uarg = u'--a=é'
-        try:
-            barg = uarg.encode(sys.stdin.encoding)
-        except (TypeError, UnicodeEncodeError):
-            raise skip("sys.stdin.encoding can't handle 'é'")
-
-        cl = self.klass(log=log)
-        config = cl.load_config([barg])
-        self.assertEqual(config.a, u'é')
-
     def test_list_append(self):
         cl = self.klass(log=log)
         argv = ["--C.list_trait", "x", "--C.list_trait", "y"]

--- a/traitlets/tests/test_traitlets.py
+++ b/traitlets/tests/test_traitlets.py
@@ -17,12 +17,49 @@ import pytest
 from pytest import mark
 
 from traitlets import (
-    HasTraits, MetaHasTraits, TraitType, Any, Bool, CBytes, Dict, Enum,
-    Int, CInt, Long, CLong, Integer, Float, CFloat, Complex, Bytes, Unicode,
-    TraitError, Union, Callable, All, Undefined, Type, This, Instance, TCPAddress,
-    List, Tuple, ObjectName, DottedObjectName, CRegExp, link, directional_link,
-    ForwardDeclaredType, ForwardDeclaredInstance, validate, observe, default,
-    observe_compat, BaseDescriptor, HasDescriptors,
+    HasTraits,
+    MetaHasTraits,
+    TraitType,
+    Any,
+    Bool,
+    CBytes,
+    Dict,
+    Enum,
+    Int,
+    CInt,
+    Long,
+    CLong,
+    Integer,
+    Float,
+    CFloat,
+    Complex,
+    Bytes,
+    Unicode,
+    TraitError,
+    Union,
+    Callable,
+    All,
+    Undefined,
+    Type,
+    This,
+    Instance,
+    TCPAddress,
+    List,
+    Tuple,
+    ObjectName,
+    DottedObjectName,
+    CRegExp,
+    link,
+    directional_link,
+    ForwardDeclaredType,
+    ForwardDeclaredInstance,
+    validate,
+    observe,
+    default,
+    observe_compat,
+    BaseDescriptor,
+    HasDescriptors,
+    CUnicode,
 )
 
 def change_dict(*ordered_values):
@@ -102,7 +139,7 @@ class TestTraitType(TestCase):
 
     def test_error(self):
         class A(HasTraits):
-            tt = TraitType
+            tt = TraitType()
         a = A()
         self.assertRaises(TraitError, A.tt.error, a, 10)
 
@@ -2624,14 +2661,18 @@ def _from_string_test(traittype, s, expected):
         assert value == expected
 
 
-@pytest.mark.parametrize('s, expected', [
-    ('xyz', 'xyz'),
-    ('1', '1'),
-    ('"xx"', '"xx"'),
-    ("'abc'", "'abc'"),
-])
+@pytest.mark.parametrize(
+    "s, expected", [("xyz", "xyz"), ("1", "1"), ('"xx"', "xx"), ("'abc'", "abc"),]
+)
 def test_unicode_from_string(s, expected):
     _from_string_test(Unicode, s, expected)
+
+
+@pytest.mark.parametrize(
+    "s, expected", [("xyz", "xyz"), ("1", "1"), ('"xx"', "xx"), ("'abc'", "abc"),]
+)
+def test_cunicode_from_string(s, expected):
+    _from_string_test(CUnicode, s, expected)
 
 
 @pytest.mark.parametrize('s, expected', [

--- a/traitlets/traitlets.py
+++ b/traitlets/traitlets.py
@@ -2174,8 +2174,8 @@ class Unicode(TraitType):
                     old_s = s
                     s = s[1:-1]
                     warn(
-                        "Supporting extra quotes around strings is deprecated in traitlets 5.0. "
-                        "Use %r instead of %r" % (s, old_s),
+                        "Supporting extra quotes around Unicode is deprecated in traitlets 5.0. "
+                        "Use %r instead of %r – or use CUnicode." % (s, old_s),
                         FutureWarning)
         return s
 
@@ -2479,7 +2479,13 @@ class Container(Instance):
 
     def from_string(self, s):
         """Load value from a single string"""
-        return self.from_string_list([s])
+        if not isinstance(s, str):
+            raise TraitError(f"Expected string, got {s!r}")
+        try:
+            test = literal_eval(s)
+        except Exception:
+            test = None
+        return self.validate(None, test)
 
     def from_string_list(self, s_list):
         """Return the value from a list of config strings
@@ -2892,7 +2898,15 @@ class Dict(Instance):
 
     def from_string(self, s):
         """Load value from a single string"""
-        return self.from_string_list([s])
+        if not isinstance(s, str):
+            raise TypeError(f"from_string expects a list, got {repr(s)} of type {type(s)}")
+        try:
+            return self.from_string_list([s])
+        except Exception:
+            test = _safe_literal_eval(s)
+            if isinstance(test, dict):
+                return test
+            raise
 
     def from_string_list(self, s_list):
         """Return the value from a list of config strings
@@ -2925,12 +2939,11 @@ class Dict(Instance):
 
         Returns a one-key dictionary
         """
+
         if '=' not in s:
             raise TraitError(
-                "'%s' options must have the form 'key=value', got %s" % (
-                    self.__class__.__name__,
-                    s,
-                )
+                "'%s' options must have the form 'key=value', got %s"
+                % (self.__class__.__name__, repr(s),)
             )
         key, value = s.split("=", 1)
 

--- a/traitlets/utils/tests/test_importstring.py
+++ b/traitlets/utils/tests/test_importstring.py
@@ -25,5 +25,5 @@ class TestImportItem(TestCase):
             "import_item accepts strings, "
             "not '%s'." % NotAString
         )
-        with self.assertRaisesRegexp(TypeError, msg):
+        with self.assertRaisesRegex(TypeError, msg):
             import_item(NotAString())


### PR DESCRIPTION
1) the standalone dashes are now accepted as argument by using a
placeholder values. Positional dashes that would be put in extra_args
are only allowed after `--`.

2) don't always use 'from_string_list([s])' as it can be ambiguous.

3) Cleanup some deprecations

4) Make aliases work, it's a bit ugly, but we process the args list and
replace the aliases we see with what they point to.